### PR TITLE
Licensing and copyright update

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 Encoding.default_external = "UTF-8"
 source 'https://supermarket.chef.io'
 
@@ -38,4 +56,3 @@ cookbook 'nfs_wrap', path: 'provision/chef/cookbooks/nfs_wrap'
 cookbook 'packer-boss-jenkins', path: 'provision/chef/cookbooks/packer-boss-jenkins'
 cookbook 'spring_tool_suite', path: 'provision/chef/cookbooks/spring_tool_suite'
 cookbook 'xubuntu-desktop-pkg', path: 'provision/chef/cookbooks/xubuntu-desktop-pkg'
-

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2015 CapitalOne
+   Copyright [yyyy] Capital One Services, LLC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Vagrantfiles/builder/Vagrantfile
+++ b/Vagrantfiles/builder/Vagrantfile
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 cfg = {}
 cfg[:cpus]        ||= "2"

--- a/Vagrantfiles/desktop/Vagrantfile
+++ b/Vagrantfiles/desktop/Vagrantfile
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 cfg = {}
 cfg[:cpus] ||= '2'
 cfg[:memory] ||= '8096'

--- a/Vagrantfiles/docker-headless/Vagrantfile
+++ b/Vagrantfiles/docker-headless/Vagrantfile
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 VAGRANTFILE_API_VERSION = "2"
 ENV['VAGRANT_DEFAULT_PROVIDER'] ||= 'docker'
 

--- a/Vagrantfiles/flamegraph/Vagrantfile
+++ b/Vagrantfiles/flamegraph/Vagrantfile
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 cfg = {}
 cfg[:cpus]        ||= "2"
 cfg[:memory]      ||= "4096"
@@ -35,4 +53,3 @@ Vagrant.configure(2) do |config|
   end
 
 end
-

--- a/Vagrantfiles/headless/Vagrantfile
+++ b/Vagrantfiles/headless/Vagrantfile
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 cfg = {}
 cfg[:cpus] ||= '1'
 cfg[:memory] ||= '4096'

--- a/Vagrantfiles/jenkinsonar/Vagrantfile
+++ b/Vagrantfiles/jenkinsonar/Vagrantfile
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 cfg = {}
 cfg[:cpus]        ||= '2'
 cfg[:memory]      ||= '8096'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # ansible galaxy file.
 # run ansible-galaxy install -r galaxy.yml
 

--- a/packer/build-amis.sh
+++ b/packer/build-amis.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 set -e
 

--- a/packer/build-boxes.sh
+++ b/packer/build-boxes.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 set -e
 set -x

--- a/packer/build-desktop-images.sh
+++ b/packer/build-desktop-images.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 set -e
 

--- a/packer/build-docker-headless-images.sh
+++ b/packer/build-docker-headless-images.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 set -e
 set -x

--- a/packer/build-docker.sh
+++ b/packer/build-docker.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 set -e
 

--- a/packer/build-flamegraph-images.sh
+++ b/packer/build-flamegraph-images.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 set -e
 

--- a/packer/build-headless-images.sh
+++ b/packer/build-headless-images.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 set -e
 

--- a/packer/build-iso-to-vm.sh
+++ b/packer/build-iso-to-vm.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 set -e
 

--- a/packer/scripts/add_ansible.sh
+++ b/packer/scripts/add_ansible.sh
@@ -1,4 +1,22 @@
 #!/bin/sh
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # hope to pick up proxy settings if we can
 . /etc/profile

--- a/packer/scripts/alpine_docker_clean.sh
+++ b/packer/scripts/alpine_docker_clean.sh
@@ -1,4 +1,22 @@
 #!/bin/sh
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 set -x
 
@@ -10,4 +28,3 @@ set -x
 apk del python-dev fakeroot pax-utils libattr attr tar abuild binutils-libs binutils libgomp pkgconf pkgconfig libgcc gmp mpfr3 mpc1 libstdc++ gcc make patch musl-dbg libc6-compat musl-dev libc-dev fortify-headers g++ build-base expat pcre git squashfs-tools file bzip2 libbz2 libcap cdrkit acct lddtree mkinitfs mtools alpine-sdk libffi gdbm ncurses-libs readline sqlite-libs py-pip
 apk -v cache clean
 du -sh /*
-

--- a/packer/scripts/base_setup.sh
+++ b/packer/scripts/base_setup.sh
@@ -1,4 +1,22 @@
 #!/bin/sh
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 set -e
 set -x
 

--- a/packer/scripts/clean_centos.sh
+++ b/packer/scripts/clean_centos.sh
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # hope to pick up proxy settings if we can
 . /etc/profile

--- a/packer/scripts/clear_udev_rules.sh
+++ b/packer/scripts/clear_udev_rules.sh
@@ -1,4 +1,22 @@
 #!/bin/sh
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # Remove traces of mac address from network configuration
 if [ -e "/etc/sysconfig/network-scripts/ifcfg-eth0" ]; then

--- a/packer/scripts/host_tools.sh
+++ b/packer/scripts/host_tools.sh
@@ -1,4 +1,22 @@
 #!/bin/sh
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 set -e
 
 # hope to pick up proxy settings if we can

--- a/packer/scripts/sanitize.sh
+++ b/packer/scripts/sanitize.sh
@@ -1,4 +1,22 @@
 #!/bin/sh
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 set -e
 
 # hope to pick up proxy settings if we can

--- a/packer/scripts/vagrant.sh
+++ b/packer/scripts/vagrant.sh
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 set -e
 
 # hope to pick up proxy settings if we can

--- a/provision/ansible/playbooks/local.yml
+++ b/provision/ansible/playbooks/local.yml
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 ---
 - hosts: all
   vars:

--- a/provision/ansible/playbooks/mysql.yml
+++ b/provision/ansible/playbooks/mysql.yml
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 ---
 - hosts: all
   roles:

--- a/provision/chef/cookbooks/configure_desktop/attributes/default.rb
+++ b/provision/chef/cookbooks/configure_desktop/attributes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 default['configure_desktop']['application_dirs'] = [
   '/usr/share/applications',
   '/home/vagrant/Desktop'

--- a/provision/chef/cookbooks/configure_desktop/metadata.rb
+++ b/provision/chef/cookbooks/configure_desktop/metadata.rb
@@ -1,2 +1,20 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 name 'configure_desktop'
 version '0.0.1'

--- a/provision/chef/cookbooks/configure_desktop/recipes/default.rb
+++ b/provision/chef/cookbooks/configure_desktop/recipes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 node['configure_desktop']['application_dirs'].each do |dir|
   directory dir do

--- a/provision/chef/cookbooks/configure_headless/attributes/defaults.rb
+++ b/provision/chef/cookbooks/configure_headless/attributes/defaults.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 default['configure_headless']['packages'] =
   %w(bash ksh git subversion unzip libtool dos2unix)
 

--- a/provision/chef/cookbooks/configure_headless/metadata.rb
+++ b/provision/chef/cookbooks/configure_headless/metadata.rb
@@ -1,2 +1,20 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 name 'configure_headless'
 version '0.0.1'

--- a/provision/chef/cookbooks/configure_headless/recipes/default.rb
+++ b/provision/chef/cookbooks/configure_headless/recipes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 include_recipe 'apt'
 
 node['configure_headless']['packages'].each do |name|

--- a/provision/chef/cookbooks/docker_install/metadata.rb
+++ b/provision/chef/cookbooks/docker_install/metadata.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 name             'docker_install'
 version          '0.0.2'
 

--- a/provision/chef/cookbooks/docker_install/recipes/default.rb
+++ b/provision/chef/cookbooks/docker_install/recipes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 docker_service 'default' do
   action [:create, :start]
 end

--- a/provision/chef/cookbooks/firewall_wrap/attributes/default.rb
+++ b/provision/chef/cookbooks/firewall_wrap/attributes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 default['firewall_wrap']['tcp_ports'] = [22]
 default['firewall_wrap']['udp_ports'] = []
 

--- a/provision/chef/cookbooks/firewall_wrap/metadata.rb
+++ b/provision/chef/cookbooks/firewall_wrap/metadata.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 name             'firewall_wrap'
 version          '0.0.1'
 

--- a/provision/chef/cookbooks/firewall_wrap/recipes/default.rb
+++ b/provision/chef/cookbooks/firewall_wrap/recipes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 include_recipe 'firewall'
 
 # open nfs ports in firewall, unless in a docker container

--- a/provision/chef/cookbooks/flamegraph/attributes/default.rb
+++ b/provision/chef/cookbooks/flamegraph/attributes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 case node[:platform]
 when 'redhat', 'centos'
   default['flamegraph']['packages'] = ['perf']

--- a/provision/chef/cookbooks/flamegraph/metadata.rb
+++ b/provision/chef/cookbooks/flamegraph/metadata.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 name 'flamegraph'
 version '0.0.1'
 

--- a/provision/chef/cookbooks/flamegraph/recipes/default.rb
+++ b/provision/chef/cookbooks/flamegraph/recipes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 include_recipe 'firewall'
 include_recipe 'nodejs'
 include_recipe 'apache2'

--- a/provision/chef/cookbooks/install_chrome/attributes/default.rb
+++ b/provision/chef/cookbooks/install_chrome/attributes/default.rb
@@ -1,1 +1,19 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 default['install_chrome']['homepage'] = 'https://github.com/capitalone/opspipeline'

--- a/provision/chef/cookbooks/install_chrome/metadata.rb
+++ b/provision/chef/cookbooks/install_chrome/metadata.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 name 'install_chrome'
 version '0.0.1'
 depends 'chrome', '~> 1.1.1'

--- a/provision/chef/cookbooks/install_chrome/recipes/default.rb
+++ b/provision/chef/cookbooks/install_chrome/recipes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 include_recipe 'chrome'
 
 chrome 'custom_preferences' do

--- a/provision/chef/cookbooks/java_install/attributes/default.rb
+++ b/provision/chef/cookbooks/java_install/attributes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 default['java_install']['java7'] = true
 default['java_install']['java8'] = true
 default['java_install']['default'] = 7

--- a/provision/chef/cookbooks/java_install/metadata.rb
+++ b/provision/chef/cookbooks/java_install/metadata.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 name    'java_install'
 version '0.0.1'
 

--- a/provision/chef/cookbooks/java_install/recipes/default.rb
+++ b/provision/chef/cookbooks/java_install/recipes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 if node['java_install']['java7']
   java_ark 'java_install_7' do

--- a/provision/chef/cookbooks/jenkins-job/attributes/default.rb
+++ b/provision/chef/cookbooks/jenkins-job/attributes/default.rb
@@ -1,2 +1,20 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 default['jenkins-job']['job-files'] = []
 default['jenkins-job']['job-dir'] = '/var/cache/jenkins-job'

--- a/provision/chef/cookbooks/jenkins-job/files/izanamee_build.xml
+++ b/provision/chef/cookbooks/jenkins-job/files/izanamee_build.xml
@@ -1,3 +1,21 @@
+<!--
+    Ops-Pipeline - Templates for automating the production and consumption of images
+    and containers.
+
+    Copyright 2016 Capital One Services, LLC.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
 <flow-definition plugin="workflow-job@1.11"><actions/><description/><keepDependencies>false</keepDependencies><properties/><definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@1.11"><script>
 env.version = "2.1.${env.BUILD_NUMBER}"
 env.kitchen = "/opt/chefdk/bin/kitchen"

--- a/provision/chef/cookbooks/jenkins-job/files/opspipeline_build.xml
+++ b/provision/chef/cookbooks/jenkins-job/files/opspipeline_build.xml
@@ -1,3 +1,21 @@
+<!--
+    Ops-Pipeline - Templates for automating the production and consumption of images
+    and containers.
+
+    Copyright 2016 Capital One Services, LLC.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
 <flow-definition plugin="workflow-job@1.11"><actions/><description/><keepDependencies>false</keepDependencies><properties/><definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@1.11"><script>
 env.version = "2.1.${env.BUILD_NUMBER}"
 env.kitchen = "/opt/chefdk/bin/kitchen"

--- a/provision/chef/cookbooks/jenkins-job/files/test_sonar.xml
+++ b/provision/chef/cookbooks/jenkins-job/files/test_sonar.xml
@@ -1,4 +1,22 @@
 <?xml version='1.0' encoding='UTF-8'?>
+<!--
+    Ops-Pipeline - Templates for automating the production and consumption of images
+    and containers.
+
+    Copyright 2016 Capital One Services, LLC.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
 <flow-definition plugin="workflow-job@1.10.1">
 <actions/>
 <description/>

--- a/provision/chef/cookbooks/jenkins-job/metadata.rb
+++ b/provision/chef/cookbooks/jenkins-job/metadata.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 name             'jenkins-job'
 version          '0.0.1'
 

--- a/provision/chef/cookbooks/jenkins-job/recipes/default.rb
+++ b/provision/chef/cookbooks/jenkins-job/recipes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 include_recipe 'packer-boss-jenkins'
 

--- a/provision/chef/cookbooks/mysql_wrap/attributes/default.rb
+++ b/provision/chef/cookbooks/mysql_wrap/attributes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 default['mysql_wrap']['port'] = '3306'
 default['mysql_wrap']['version'] = '5.5'
 default['mysql_wrap']['admin_password'] = 'change me'

--- a/provision/chef/cookbooks/mysql_wrap/metadata.rb
+++ b/provision/chef/cookbooks/mysql_wrap/metadata.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 name             'mysql_wrap'
 version          '0.0.4'
 

--- a/provision/chef/cookbooks/mysql_wrap/recipes/default.rb
+++ b/provision/chef/cookbooks/mysql_wrap/recipes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 if node['mysql_wrap']['create']
   mysql_service 'mysqld' do
     port node['mysql_wrap']['port']

--- a/provision/chef/cookbooks/nfs_wrap/metadata.rb
+++ b/provision/chef/cookbooks/nfs_wrap/metadata.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 name 'nfs_wrap'
 version '0.0.1'
 

--- a/provision/chef/cookbooks/nfs_wrap/recipes/default.rb
+++ b/provision/chef/cookbooks/nfs_wrap/recipes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 include_recipe 'firewall'
 
 # open nfs ports in firewall unless running

--- a/provision/chef/cookbooks/packer-boss-jenkins/attributes/default.rb
+++ b/provision/chef/cookbooks/packer-boss-jenkins/attributes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 default['jenkins-master']['build-xml'] = 'opspipeline-build.xml'
 default['jenkins-master']['admin_private_key'] = 'you should set this'
 default['jenkins-master']['admin_public_key'] = 'you should set this'

--- a/provision/chef/cookbooks/packer-boss-jenkins/metadata.rb
+++ b/provision/chef/cookbooks/packer-boss-jenkins/metadata.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 name             'packer-boss-jenkins'
 version          '0.0.1'
 

--- a/provision/chef/cookbooks/packer-boss-jenkins/recipes/default.rb
+++ b/provision/chef/cookbooks/packer-boss-jenkins/recipes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 include_recipe 'jenkins::master'
 
 jenkins_user node['jenkins-master']['admin_username'] do

--- a/provision/chef/cookbooks/spring_tool_suite/attributes/default.rb
+++ b/provision/chef/cookbooks/spring_tool_suite/attributes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 default['spring_tool_suite']['application_dirs'] = [
   '/usr/share/applications',
   '/home/vagrant/Desktop'

--- a/provision/chef/cookbooks/spring_tool_suite/metadata.rb
+++ b/provision/chef/cookbooks/spring_tool_suite/metadata.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 name 'spring_tool_suite'
 version '0.0.1'
 

--- a/provision/chef/cookbooks/spring_tool_suite/recipes/default.rb
+++ b/provision/chef/cookbooks/spring_tool_suite/recipes/default.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 directory node['spring_tool_suite']['sts_homedir'] do
   owner 'root'

--- a/provision/chef/cookbooks/xubuntu-desktop-pkg/metadata.rb
+++ b/provision/chef/cookbooks/xubuntu-desktop-pkg/metadata.rb
@@ -1,3 +1,20 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 name             'xubuntu-desktop-pkg'
 version          '0.0.1'
-

--- a/provision/chef/cookbooks/xubuntu-desktop-pkg/recipes/default.rb
+++ b/provision/chef/cookbooks/xubuntu-desktop-pkg/recipes/default.rb
@@ -1,1 +1,19 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 package 'xubuntu-desktop'

--- a/test/integration/desktop/serverspec/bash_aliases_spec.rb
+++ b/test/integration/desktop/serverspec/bash_aliases_spec.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'spec_helper'
 
 describe file('/etc/profile.d/bash_alias_iz.sh') do

--- a/test/integration/desktop/serverspec/binaries_at_version_spec.rb
+++ b/test/integration/desktop/serverspec/binaries_at_version_spec.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'spec_helper'
 require 'mkmf'
 

--- a/test/integration/desktop/serverspec/guest_tools_spec.rb
+++ b/test/integration/desktop/serverspec/guest_tools_spec.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'spec_helper'
 
 describe 'guest tools present' do

--- a/test/integration/desktop/serverspec/maven_settings_spec.rb
+++ b/test/integration/desktop/serverspec/maven_settings_spec.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'spec_helper'
 
 describe file('/home/vagrant/.m2/settings.xml') do

--- a/test/integration/desktop/serverspec/spec_helper.rb
+++ b/test/integration/desktop/serverspec/spec_helper.rb
@@ -1,2 +1,20 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'serverspec'
 set :backend, :exec

--- a/test/integration/desktop/serverspec/sts_configuration_spec.rb
+++ b/test/integration/desktop/serverspec/sts_configuration_spec.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'spec_helper'
 
 describe file('/usr/share/applications/STS.desktop') do

--- a/test/integration/flamegraph/serverspec/localhost/bash_aliases_spec.rb
+++ b/test/integration/flamegraph/serverspec/localhost/bash_aliases_spec.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'spec_helper'
 
 describe file('/etc/profile.d/bash_alias_iz.sh') do

--- a/test/integration/flamegraph/serverspec/localhost/binaries_at_version_spec.rb
+++ b/test/integration/flamegraph/serverspec/localhost/binaries_at_version_spec.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'spec_helper'
 require 'mkmf'
 

--- a/test/integration/flamegraph/serverspec/localhost/maven_settings_spec.rb
+++ b/test/integration/flamegraph/serverspec/localhost/maven_settings_spec.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'spec_helper'
 
 describe file('/home/vagrant/.m2/settings.xml') do

--- a/test/integration/flamegraph/serverspec/spec_helper.rb
+++ b/test/integration/flamegraph/serverspec/spec_helper.rb
@@ -1,2 +1,20 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'serverspec'
 set :backend, :exec

--- a/test/integration/headless/serverspec/localhost/bash_aliases_spec.rb
+++ b/test/integration/headless/serverspec/localhost/bash_aliases_spec.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'spec_helper'
 
 describe file('/etc/profile.d/bash_alias_iz.sh') do

--- a/test/integration/headless/serverspec/localhost/binaries_at_version_spec.rb
+++ b/test/integration/headless/serverspec/localhost/binaries_at_version_spec.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'spec_helper'
 require 'mkmf'
 

--- a/test/integration/headless/serverspec/localhost/maven_settings_spec.rb
+++ b/test/integration/headless/serverspec/localhost/maven_settings_spec.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'spec_helper'
 
 describe file('/home/vagrant/.m2/settings.xml') do

--- a/test/integration/headless/serverspec/localhost/open_ports_spec.rb
+++ b/test/integration/headless/serverspec/localhost/open_ports_spec.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'spec_helper'
 
 tcp_ports = %w(22 2049 111)

--- a/test/integration/headless/serverspec/spec_helper.rb
+++ b/test/integration/headless/serverspec/spec_helper.rb
@@ -1,2 +1,20 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'serverspec'
 set :backend, :exec

--- a/test/integration/jenkins/serverspec/localhost/bash_aliases_spec.rb
+++ b/test/integration/jenkins/serverspec/localhost/bash_aliases_spec.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'spec_helper'
 
 describe file('/etc/profile.d/bash_alias_iz.sh') do

--- a/test/integration/jenkins/serverspec/localhost/binaries_at_version_spec.rb
+++ b/test/integration/jenkins/serverspec/localhost/binaries_at_version_spec.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'spec_helper'
 require 'mkmf'
 

--- a/test/integration/jenkins/serverspec/localhost/jenkins_listening_spec.rb
+++ b/test/integration/jenkins/serverspec/localhost/jenkins_listening_spec.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'spec_helper'
 
 set :path, '/bin:/sbin:/usr/local/sbin:/usr/bin:/usr/sbin:$PATH'

--- a/test/integration/jenkins/serverspec/localhost/maven_settings_spec.rb
+++ b/test/integration/jenkins/serverspec/localhost/maven_settings_spec.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'spec_helper'
 
 describe file('/home/vagrant/.m2/settings.xml') do

--- a/test/integration/jenkins/serverspec/spec_helper.rb
+++ b/test/integration/jenkins/serverspec/spec_helper.rb
@@ -1,2 +1,20 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'serverspec'
 set :backend, :exec

--- a/test/integration/mysql/serverspec/localhost/mysql_spec.rb
+++ b/test/integration/mysql/serverspec/localhost/mysql_spec.rb
@@ -1,3 +1,21 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'spec_helper'
 
 set :path, '/bin:/sbin:/usr/local/sbin:/usr/bin:/usr/sbin:$PATH'

--- a/test/integration/mysql/serverspec/spec_helper.rb
+++ b/test/integration/mysql/serverspec/spec_helper.rb
@@ -1,2 +1,20 @@
+#
+# Ops-Pipeline - Templates for automating the production and consumption of images
+# and containers.
+#
+# Copyright 2016 Capital One Services, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 require 'serverspec'
 set :backend, :exec


### PR DESCRIPTION
This information was updated using the 'copyright-header' gem. Here is the command that was ran.

```bash
copyright-header --add-path packer:provision:test:Vagrantfiles:. \
                 --license ASL2 \
                 --guess-extension \
                 --copyright-holder 'Capital One Services, LLC.' \
                 --copyright-software 'Ops-Pipeline' \
                 --copyright-software-description 'Templates for automating the production and consumption of images and containers.' \
                 --copyright-year 2016 \
                 --output-dir ./
```

Let me know if something is missing or if something looks off.